### PR TITLE
Add least-privilege permissions to merge deploy workflow

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -6,6 +6,8 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Fixes the GitHub **code scanning** alert `actions/missing-workflow-permissions` (medium) on `.github/workflows/firebase-hosting-merge.yml`.

The merge-to-live deploy workflow declared no top-level `permissions` block, so `GITHUB_TOKEN` defaulted to broad access. This scopes it to the minimum the job needs:

```yaml
permissions:
  contents: read
```

The merge job only checks out the repo and deploys via a Firebase service account — it does not need write scopes. (The PR preview workflow already declares its own `permissions`.)

## Security alert status
- Dependabot: 0 open alerts
- Code scanning: this PR resolves the only open alert
- Secret scanning: 1 open alert (Firebase web API key in git history) — handled separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)